### PR TITLE
feat: add sensitive parameter on $apiToken props

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -16,8 +16,12 @@ class Api
 
     protected array $queryParameters = [];
 
-    public function __construct(private readonly string $apiUrl, private readonly string $apiToken, private readonly array $additionalHeaders = [])
-    {
+    public function __construct(
+        private readonly string $apiUrl,
+        #[\SensitiveParameter]
+        private readonly string $apiToken,
+        private readonly array $additionalHeaders = []
+    ) {
         $this->httpClient = new HttpClient();
     }
 

--- a/src/Weaviate.php
+++ b/src/Weaviate.php
@@ -18,8 +18,12 @@ class Weaviate
     private GraphQL $graphQL;
     private Meta $meta;
 
-    public function __construct(string $apiUrl, string $apiToken, array $additionalHeaders = [])
-    {
+    public function __construct(
+        string $apiUrl,
+        #[\SensitiveParameter]
+        string $apiToken,
+        array $additionalHeaders = []
+    ) {
         $this->api = new Api($apiUrl, $apiToken, $additionalHeaders);
     }
 


### PR DESCRIPTION
Support hiding sensitive values using the new `#[\SensitiveParameter]` attribute marker (PHP 8.2).

PHP Documentation: https://www.php.net/manual/en/class.sensitiveparameter