### PR TITLE
fixes Schema addProperty method and endpoint

### DIFF
--- a/src/Api/Schema.php
+++ b/src/Api/Schema.php
@@ -41,7 +41,7 @@ class Schema extends Endpoint
     public function addProperty(string $className, array $data): PropertyModel
     {
         return new PropertyModel(
-            $this->api->put(self::ENDPOINT . '/' . $className, $data)->json()
+            $this->api->post(self::ENDPOINT . '/' . $className . '/properties', $data)->json()
         );
     }
 


### PR DESCRIPTION
Hey @timkley, thanks for this great package. 

Noticed a small issue when using Schema's `addProperty` method. According to the docs it should be a POST request to `v1/schema/{class_name}/properties`.

Tests are ok.

Ref.: https://weaviate.io/developers/weaviate/api/rest/schema#add-a-property