### PR TITLE
Handle modules with missing metadata, eg. name and documentationHref

### DIFF
--- a/src/Model/ModuleModel.php
+++ b/src/Model/ModuleModel.php
@@ -11,9 +11,9 @@ class ModuleModel extends Model
     public function __construct(array $data)
     {
         $this->key = (string) array_key_first($data);
-        $data = $data[$this->key];
-        $this->name = $data['name'];
-        $this->documentationHref = $data['documentationHref'];
+        $data = $data[$this->key] ?? [];
+        $this->name = $data['name'] ?? '';
+        $this->documentationHref = $data['documentationHref'] ?? '';
     }
 
     public function getKey(): string


### PR DESCRIPTION
Default docker of Weaviate contains one module, which does not have metadata, while existing ModuleModel code assumed 'name' and 'documentationHref' are always present. It caused an error while trying to get meta via $client->meta()->get() for the base docker version of Weaviate. The fix defaults 'name' and 'documentationHref' to empty strings if they are not found.