### PR TITLE
fix DataObject Collection to return only objects key

### DIFF
--- a/src/Api/DataObject.php
+++ b/src/Api/DataObject.php
@@ -12,8 +12,9 @@ class DataObject extends Endpoint
 
     public function get(): ObjectCollection
     {
+        $items = $this->api->get(self::ENDPOINT)->json();
         return new ObjectCollection(
-            $this->api->get(self::ENDPOINT)->json()
+            isset($items['objects']) ? $items['objects'] : $items
         );
     }
 


### PR DESCRIPTION
Fix DataObject Collection because it returns the json representation of Weaviate resultset, instead of a Collection of "objects" key.
It was not possible to make a foreach of items because the items representation is inside "objects" and not on the root of the json object.